### PR TITLE
permit custom device requests

### DIFF
--- a/pkg/controllers/provisioning/scheduling/inflightnode.go
+++ b/pkg/controllers/provisioning/scheduling/inflightnode.go
@@ -108,7 +108,8 @@ func (n *InFlightNode) Add(ctx context.Context, pod *v1.Pod) error {
 
 	// check resource requests first since that's a pretty likely reason the pod won't schedule on an in-flight
 	// node, which at this point can't be increased in size
-	requests := resources.Merge(n.requests, resources.RequestsForPods(pod))
+	podRequests := state.FilterWellKnownRequests(ctx, resources.RequestsForPods(pod))
+	requests := resources.Merge(n.requests, podRequests)
 
 	if !resources.Fits(requests, n.available) {
 		return fmt.Errorf("exceeds node resources")

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -196,8 +196,8 @@ func (c *Cluster) populateResourceRequests(ctx context.Context, node *v1.Node, n
 	var daemonsetLimits []v1.ResourceList
 	for i := range pods.Items {
 		pod := &pods.Items[i]
-		requests := resources.RequestsForPods(pod)
-		podLimits := resources.LimitsForPods(pod)
+		requests := FilterWellKnownRequests(ctx, resources.RequestsForPods(pod))
+		podLimits := FilterWellKnownRequests(ctx, resources.LimitsForPods(pod))
 		podKey := client.ObjectKeyFromObject(pod)
 
 		n.podRequests[podKey] = requests


### PR DESCRIPTION
Karpenter is negative towards custom device requests it is unaware of, assuming those cannot be scheduled.

fixes aws/karpenter-core#751

This changes the request handling to be scoped only to resource request that Karpenter is aware of and actively manages. The reasoning here is that it cannot influence those resource requests anyways, they come into existance by means of other concepts such as the device-plugin manager that even might be late bound and thus it is out of scope.

<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

**How was this change tested?**

*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
